### PR TITLE
CI: pin runner image version

### DIFF
--- a/.github/workflows/schedule.yml
+++ b/.github/workflows/schedule.yml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   check_date:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     name: Check latest commit
     outputs:
       should_run: ${{ steps.should_run.outputs.should_run }}
@@ -24,7 +24,7 @@ jobs:
   connectedCheck:
     needs: check_date
     if: ${{ needs.check_date.outputs.should_run != 'false' }}
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     strategy:
       matrix:
         BUILD_SDK: [24, 31, 34]


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Updated the environment configuration for GitHub Actions to use Ubuntu 22.04.
	- Implemented a check in the workflow to determine if the latest commit is less than 24 hours old, affecting subsequent job execution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->